### PR TITLE
compute score on completions trigger

### DIFF
--- a/src/lib/db/games.ts
+++ b/src/lib/db/games.ts
@@ -9,7 +9,20 @@ export default {
 	},
 
 	async one(client: TypedSupabaseClient, gameId: string) {
-		return wrap(client.from(table).select().eq('id', gameId).single());
+		return wrap(
+			client
+				.from(table)
+				.select(
+					`
+					id,
+					label,
+					description,
+					card_size
+				`
+				)
+				.eq('id', gameId)
+				.single()
+		);
 	},
 
 	async members(client: TypedSupabaseClient, gameId: string) {
@@ -24,6 +37,7 @@ export default {
 				`
 				)
 				.eq('games_users.game_id', gameId)
+				.order('display_name', { ascending: true })
 		);
 	}
 };

--- a/src/routes/cards/[cardId]/+page.ts
+++ b/src/routes/cards/[cardId]/+page.ts
@@ -4,7 +4,7 @@ import { withAuthenticatedSupabase } from '$lib/db/utils';
 
 export const load = (async (event) =>
 	withAuthenticatedSupabase(event, async (supabaseClient) => {
-		const card = await Cards.one(supabaseClient, event.params.cardId);
+		const card = await Cards.oneComplete(supabaseClient, event.params.cardId);
 
 		return {
 			game: await Cards.gameFor(supabaseClient, event.params.cardId),

--- a/src/routes/games/[gameId]/+page.svelte
+++ b/src/routes/games/[gameId]/+page.svelte
@@ -1,40 +1,56 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { enhance } from '$app/forms';
-	import CardMini from '$lib/CardMini.svelte';
 
 	export let data: PageData;
 
-	$: wins = data.wins;
+	$: game = data.game;
+	$: cards = data.cards;
 
-	// TODO: cards/score is a better first UI than players. The list of all players
-	// should be accessible but not prevalent.
+	// This is a progressive enhancement which allows clicking from the whole row
+	const handleCardClick = (evt: Event) => {
+		(evt.target as HTMLElement).querySelector('a')?.click();
+	};
 </script>
 
 <form method="POST" action="?/createCard" use:enhance>
 	<button class="btn btn-success">New Card</button>
 </form>
-{#if data?.game}
+
+{#if game}
 	<div class="m-2 md:max-w-prose md:mx-auto">
-		<h2 class="card-title text-accent">{data.game.label}</h2>
-		<p class="mb-2">{data.game.description}</p>
-		{#if data.cards}
-			{#each data.cards as card}
-				{#if card}
-					<a class="block mb-2" href="/cards/{card.id}">
-						<div class="card card-side bg-base-200 hover shadow-xl">
-							<div class="card-body">
-								<h2 class="card-title">
-									{card.user_profiles.display_name}
-								</h2>
-							</div>
-							<div class="mr-3 absolute top-0 right-0 bottom-0 flex items-center justify-center">
-								<CardMini {card} {wins} />
-							</div>
-						</div>
-					</a>
-				{/if}
-			{/each}
+		<h2 class="card-title text-accent">{game.label}</h2>
+		<p class="mb-2">{game.description}</p>
+
+		{#if cards}
+			<div class="overflow-x-auto">
+				<table class="table table-zebra w-full">
+					<thead>
+						<tr>
+							<th>Card</th>
+							<th class="text-right">Score</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each cards as card}
+							<tr class="hover cursor-pointer" on:click={handleCardClick}>
+								<td>
+									<a class="block" href="/cards/{card?.id}">
+										{card?.user_profiles.display_name ?? 'Player 1'}
+									</a>
+								</td>
+								<td class="text-right">
+									{#if card.scores.score == game.card_size}
+										<span class="font-bold text-primary animate-pulse">WINNER!</span>
+									{:else}
+										{card.scores.score ?? 0}
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
 		{/if}
 	</div>
 {/if}

--- a/src/routes/games/[gameId]/+page.svelte
+++ b/src/routes/games/[gameId]/+page.svelte
@@ -9,7 +9,7 @@
 
 	// This is a progressive enhancement which allows clicking from the whole row
 	const handleCardClick = (evt: Event) => {
-		(evt.target as HTMLElement).querySelector('a')?.click();
+		(evt.currentTarget as HTMLElement).querySelector('a')?.click();
 	};
 </script>
 

--- a/src/routes/games/[gameId]/+page.ts
+++ b/src/routes/games/[gameId]/+page.ts
@@ -1,17 +1,10 @@
 import { withAuthenticatedSupabase } from '$lib/db/utils';
-import Cards, { getWinningCompletions } from '$lib/db/cards';
+import Cards from '$lib/db/cards';
 import Games from '$lib/db/games';
 import type { PageLoad } from './$types';
 
 export const load = (async (event) =>
-	withAuthenticatedSupabase(event, async (supabaseClient) => {
-		const cards = await Cards.allForGame(supabaseClient, event.params.gameId);
-
-		const wins: Set<string> = new Set();
-
-		return {
-			game: await Games.one(supabaseClient, event.params.gameId),
-			cards,
-			wins: cards?.reduce((set, card) => getWinningCompletions(card, set), wins) ?? wins
-		};
-	})) satisfies PageLoad;
+	withAuthenticatedSupabase(event, async (supabaseClient) => ({
+		game: await Games.one(supabaseClient, event.params.gameId),
+		cards: await Cards.allForGame(supabaseClient, event.params.gameId)
+	}))) satisfies PageLoad;


### PR DESCRIPTION
This adds a `scores` table (`card_id`, `score`) and computes the score for a card on updates to `completions`. This is now used by the UI in the `/games/[gameId]/` route.

Potential future improvements:
- Only compute score if the completion state changed
- I think this is computing the score N times when the card is created, maybe only do that once?